### PR TITLE
Transform keys is now supported in ruby since 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.0
-before_install: gem install bundler -v 2.0.1
+  - 3.1.2
+before_install: gem install bundler -v 2.3.6

--- a/lib/core_ext/stringify_keys.rb
+++ b/lib/core_ext/stringify_keys.rb
@@ -1,20 +1,4 @@
 class Hash
-  # Stolen from ActiveSupport
-  def transform_keys
-    return enum_for(:transform_keys) { size } unless block_given?
-    result = {}
-    each_key do |key|
-      result[yield(key)] = self[key]
-    end
-    result
-  end
-
-  # Returns a new hash with all keys converted to strings.
-  #
-  #   hash = { name: 'Rob', age: '28' }
-  #
-  #   hash.stringify_keys
-  #   # => {"name"=>"Rob", "age"=>"28"}
   def stringify_keys
     transform_keys(&:to_s)
   end

--- a/lib/json_logic/version.rb
+++ b/lib/json_logic/version.rb
@@ -1,3 +1,3 @@
 module JSONLogic
-  VERSION = '0.4.7'
+  VERSION = '0.4.8'
 end


### PR DESCRIPTION
Transform keys is now supported in ruby since 2.5, so this is causing issues with old code for transform_keys